### PR TITLE
Deactivate customer

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -175,6 +175,25 @@ def delete_customers(customer_id):
     app.logger.info("Customer with ID [%s] delete complete.", customer_id)
     return make_response("", status.HTTP_204_NO_CONTENT)
 
+### -----------------------------------------------------------
+### DEACTIVATE AN EXISTING CUSTOMERS
+### -----------------------------------------------------------
+@app.route("/customers/<int:customer_id>/deactivate", methods=["PUT"])
+def deactivate_customers(customer_id):
+    """
+    Deactivate a Customer
+    """
+    app.logger.info("Request to deactivate customer with id: %s", customer_id)
+    check_content_type("application/json")
+    customer = Customer.find(customer_id, filter_activate=False)
+    if not customer:
+        raise NotFound("Customer with id '{}' was not found.".format(customer_id))
+    customer.active = False
+    customer.customer_id = customer_id
+    customer.save()
+
+    app.logger.info("Customer with ID [%s] deactivated.", customer.customer_id)
+    return make_response(jsonify(customer.serialize()), status.HTTP_200_OK)
 
 ### -----------------------------------------------------------
 ### Auxiliary Utilites

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -204,6 +204,22 @@ class TestCustomers(unittest.TestCase):
         _ = Customer.remove_all()
         self.assertEqual(len(Customer.all()), 0)
 
+    def test_deactivate_customer(self):
+        """
+        Deactivate a customer
+        """
+        customer = Customer (
+            first_name="Shuhong",
+            last_name="Cai",
+            user_id="sc8540@nyu.edu",
+            password="password",
+            active = True
+        )
+        customer.save()
+        self.assertEqual(customer.active, True)
+        customer.active = False
+        self.assertEqual(customer.active, False)
+
     def test_list_customers(self):
         """ 
         List all Customers

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -319,20 +319,13 @@ class TestCustomerServer(unittest.TestCase):
         Deactivate a customer by ID
         """
         # create a Customer to deactivate
-        test_customer = CustomerFactory()
-        resp = self.app.post(
-            "/customers", 
-            json=test_customer.serialize(), 
-            content_type="application/json"
-        )
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        original_customer = resp.get_json()
+        test_customer = self._fake_customers(1)[0]
         # make sure the original customer is active
-        self.assertEqual(original_customer["active"], True)
+        self.assertEqual(test_customer.active, True)
 
         # deactivate the customer
         resp = self.app.put(
-            "/customers/{}/deactivate".format(new_account["id"]),
+            "/customers/{}/deactivate".format(test_customer.customer_id),
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -313,3 +313,28 @@ class TestCustomerServer(unittest.TestCase):
         # make sure they are deleted
         resp = self.app.get('/customers/{}'.format(test_customer.customer_id), content_type=CONTENT_TYPE_JSON)
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_deactivate_customer(self):
+        """
+        Deactivate a customer by ID
+        """
+        # create a Customer to deactivate
+        test_customer = CustomerFactory()
+        resp = self.app.post(
+            "/customers", 
+            json=test_customer.serialize(), 
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        original_customer = resp.get_json()
+        # make sure the original customer is active
+        self.assertEqual(original_customer["active"], True)
+
+        # deactivate the customer
+        resp = self.app.put(
+            "/customers/{}/deactivate".format(new_account["id"]),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        deactivated_customer = resp.get_json()
+        self.assertEqual(deactivated_customer["active"], False)


### PR DESCRIPTION
Deactivate a customer with given ID.

When `PUT /customer/{id}/deactivate` called, if the customer with given ID exists, its `active` property will be set to `False`. And the customer info will be returned with code 200.
If the customer does not exists, it will return code 404.
Test cases in models and service are included.

Code coverage is 93% now.