### PR TITLE
Activate customer

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -179,7 +179,7 @@ def delete_customers(customer_id):
 ### ACTIVATE AN EXISTING CUSTOMERS
 ### -----------------------------------------------------------
 @app.route("/customers/<int:customer_id>/activate", methods=["PUT"])
-def deactivate_customers(customer_id):
+def activate_customers(customer_id):
     """
     Activate a Customer
     """

--- a/service/routes.py
+++ b/service/routes.py
@@ -175,6 +175,25 @@ def delete_customers(customer_id):
     app.logger.info("Customer with ID [%s] delete complete.", customer_id)
     return make_response("", status.HTTP_204_NO_CONTENT)
 
+### -----------------------------------------------------------
+### ACTIVATE AN EXISTING CUSTOMERS
+### -----------------------------------------------------------
+@app.route("/customers/<int:customer_id>/activate", methods=["PUT"])
+def deactivate_customers(customer_id):
+    """
+    Activate a Customer
+    """
+    app.logger.info("Request to activate customer with id: %s", customer_id)
+    check_content_type("application/json")
+    customer = Customer.find(customer_id, filter_activate=False)
+    if not customer:
+        raise NotFound("Customer with id '{}' was not found.".format(customer_id))
+    customer.active = True
+    customer.customer_id = customer_id
+    customer.save()
+
+    app.logger.info("Customer with ID [%s] activated.", customer.customer_id)
+    return make_response(jsonify(customer.serialize()), status.HTTP_200_OK)
 
 ### -----------------------------------------------------------
 ### Auxiliary Utilites

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -204,6 +204,22 @@ class TestCustomers(unittest.TestCase):
         _ = Customer.remove_all()
         self.assertEqual(len(Customer.all()), 0)
 
+    def test_activate_customer(self):
+        """
+        Activate a customer
+        """
+        customer = Customer (
+            first_name="Shuhong",
+            last_name="Cai",
+            user_id="sc8540@nyu.edu",
+            password="password",
+            active = False
+        )
+        customer.save()
+        self.assertEqual(customer.active, False)
+        customer.active = True
+        self.assertEqual(customer.active, True)
+
     def test_list_customers(self):
         """ 
         List all Customers

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -318,7 +318,7 @@ class TestCustomerServer(unittest.TestCase):
         """
         Activate a customer by ID
         """
-        # create a Customer to deactivate
+        # create a Customer to activate
         test_customer = self._fake_customers(1)[0]
         test_customer.active = False
         # make sure the original customer is not active
@@ -330,5 +330,5 @@ class TestCustomerServer(unittest.TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        deactivated_customer = resp.get_json()
-        self.assertEqual(deactivated_customer["active"], True) 
+        activated_customer = resp.get_json()
+        self.assertEqual(activated_customer["active"], True) 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -313,3 +313,22 @@ class TestCustomerServer(unittest.TestCase):
         # make sure they are deleted
         resp = self.app.get('/customers/{}'.format(test_customer.customer_id), content_type=CONTENT_TYPE_JSON)
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_activate_customer(self):
+        """
+        Activate a customer by ID
+        """
+        # create a Customer to deactivate
+        test_customer = self._fake_customers(1)[0]
+        test_customer.active = False
+        # make sure the original customer is not active
+        self.assertEqual(test_customer.active, False)
+
+        # activate the customer
+        resp = self.app.put(
+            "/customers/{}/activate".format(test_customer.customer_id),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        deactivated_customer = resp.get_json()
+        self.assertEqual(deactivated_customer["active"], True) 


### PR DESCRIPTION
Activate a customer with given ID.

When `PUT /customer/{id}/activate` called, if the customer with given ID exists, its active property will be set to `True`. And the customer info will be returned with code 200.
If the customer does not exists, it will return code 404.
Test cases in models and service are included.