### PR TITLE
Compatibility for running behave on M1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(2) do |config|
   ############################################################
   config.vm.provider :docker do |docker, override|
     override.vm.box = nil
-    docker.image = "rofrano/vagrant-provider:ubuntu"
+    docker.image = "rofrano/vagrant-provider:debian"
     docker.remains_running = true
     docker.has_ssh = true
     docker.privileged = true
@@ -84,7 +84,7 @@ Vagrant.configure(2) do |config|
     # Install Python 3 and dev tools 
     apt-get update
     apt-get install -y chromium-chromedriver
-    apt-get install -y git tree wget vim python3-dev python3-pip python3-venv apt-transport-https
+    apt-get install -y git tree wget vim python3-dev python3-pip python3-venv apt-transport-https python3-selenium
     apt-get upgrade python3
     
     # Need PostgreSQL development library to compile on arm64


### PR DESCRIPTION
This PR changes:
1. Image for Vagrant environment from Ubuntu to Debian for Docker provider
2. Add `python3-selenium` when running `apt-get install`

These changes provide compatibility for running `behave` on Vagrant envrionment on M1 chip, and are supposed to have no effects for other users.

After these changes, developers should
- For Apple M1 users: Run `vagrant destroy` and `vagrant up`
- For other users: Run `vagrant provision`